### PR TITLE
增加Native打包支持（Issue #1）

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,64 @@ spring.ai.mcp.client.stdio.servers-configuration=classpath:/mcp-servers-config.j
    java -Dai.user.input='查询飞书文档信息' -jar target/mcp-starter-default-client-0.0.1-SNAPSHOT.jar
    ```
 
+## Native Image 支持
+
+Feicur 支持使用 GraalVM Native Image 技术构建原生可执行文件，这可以显著提高启动速度并减少内存占用。
+
+### 使用 Buildpacks 构建 Native Image 容器
+
+使用 Spring Boot 的 Buildpacks 支持可以生成包含原生可执行文件的轻量级容器：
+
+```bash
+# 使用 Maven
+./mvnw -Pnative spring-boot:build-image
+
+# 运行容器
+docker run --rm -p 8080:8080 \
+  -e FEICUR_LLM_API_KEY=your-openai-api-key \
+  -e FEICUR_LLM_BASE_URL=https://api.openai.com/v1 \
+  -e FEICUR_LLM_MODEL=gpt-4o \
+  docker.io/library/mcp-starter-default-client:0.0.1-SNAPSHOT
+```
+
+### 使用 Native Build Tools 直接构建 Native 可执行文件
+
+#### 前提条件
+
+- GraalVM 或 Liberica Native Image Kit (NIK) 22.3+
+- 对于 Linux/macOS，推荐使用 SDKMAN! 安装：
+  ```bash
+  sdk install java 22.3.r17-nik
+  sdk use java 22.3.r17-nik
+  ```
+
+#### 构建和运行
+
+```bash
+# 使用 Maven 构建 Native 可执行文件
+./mvnw -Pnative native:compile
+
+# 运行 Native 可执行文件
+FEICUR_LLM_API_KEY=your-openai-api-key \
+FEICUR_LLM_BASE_URL=https://api.openai.com/v1 \
+FEICUR_LLM_MODEL=gpt-4o \
+./target/mcp-starter-default-client
+```
+
+### 性能优势
+
+Native Image 相比传统 JVM 应用程序具有以下优势：
+
+- 显著更快的启动时间（通常为毫秒级而非秒级）
+- 更低的内存占用
+- 更小的部署体积
+- 无需安装 JVM 即可运行
+
 ## 其他资源
 
 - [Spring AI 文档](https://docs.spring.io/spring-ai/reference/)
 - [MCP 客户端启动器](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-client-boot-starter-docs.html)
 - [模型上下文协议规范](https://modelcontextprotocol.github.io/specification/)
 - [Spring Boot 文档](https://docs.spring.io/spring-boot/docs/current/reference/html/)
+- [Spring Boot GraalVM Native Image 支持](https://docs.spring.io/spring-boot/docs/current/reference/html/native-image.html)
 - [飞书开放平台文档](https://open.feishu.cn/document/home/index)

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<spring-ai.version>1.0.0-SNAPSHOT</spring-ai.version>
+		<native-buildtools.version>0.10.1</native-buildtools.version>
 	</properties>
 
 	<dependencyManagement>
@@ -56,6 +57,22 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+					<image>
+						<builder>paketobuildpacks/builder-jammy-tiny:latest</builder>
+					</image>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.graalvm.buildtools</groupId>
+				<artifactId>native-maven-plugin</artifactId>
+				<version>${native-buildtools.version}</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/org/springframework/ai/mcp/samples/client/config/NativeImageConfiguration.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/config/NativeImageConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.config;
+
+import org.springframework.ai.mcp.samples.client.Application;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
+
+/**
+ * 配置类，用于注册GraalVM Native Image所需的运行时提示。
+ * 这些提示帮助GraalVM在构建原生镜像时正确处理反射、资源和代理等。
+ */
+@Configuration
+@ImportRuntimeHints(NativeImageConfiguration.NativeImageHints.class)
+public class NativeImageConfiguration {
+
+    /**
+     * 运行时提示注册器，用于注册应用程序所需的反射和资源访问。
+     */
+    static class NativeImageHints implements RuntimeHintsRegistrar {
+        @Override
+        public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+            // 注册主应用类
+            hints.reflection().registerType(Application.class, 
+                    MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                    MemberCategory.INVOKE_DECLARED_METHODS,
+                    MemberCategory.INVOKE_PUBLIC_METHODS,
+                    MemberCategory.DECLARED_FIELDS);
+            
+            // 注册配置文件资源
+            hints.resources().registerPattern("application.properties");
+            hints.resources().registerPattern("mcp-servers-config.json");
+        }
+    }
+}

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "org.springframework.ai.mcp.samples.client.Application",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  }
+]

--- a/src/main/resources/META-INF/native-image/resource-config.json
+++ b/src/main/resources/META-INF/native-image/resource-config.json
@@ -1,0 +1,19 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\QMETA-INF/spring.factories\\E"
+      },
+      {
+        "pattern": "\\QMETA-INF/spring/aot.factories\\E"
+      },
+      {
+        "pattern": "\\Qapplication.properties\\E"
+      },
+      {
+        "pattern": "\\Qmcp-servers-config.json\\E"
+      }
+    ]
+  },
+  "bundles": []
+}


### PR DESCRIPTION
实现了Issue #1 的需求，为项目增加了Native打包支持。

主要更改：
1. 添加了GraalVM Native Build Tools Maven插件
2. 配置了Spring Boot Maven插件以支持Native Image构建
3. 添加了必要的反射和资源配置文件
4. 创建了RuntimeHints配置类以确保正确处理反射和资源
5. 更新了README.md，添加了Native Image构建和运行说明

这些更改使项目能够：
- 使用Spring Boot Buildpacks构建Native Image容器
- 使用GraalVM Native Build Tools直接构建Native可执行文件

Native Image相比传统JVM应用程序具有更快的启动时间和更低的内存占用。