### PR TITLE
feat: 实现文档监听与指令消费功能

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Feicur MVP 构建脚本
+echo "🚀 开始构建 Feicur MVP..."
+
+# 检查 Java 版本
+java_version=$(java -version 2>&1 | grep -oP 'version "?(1\.)?\K\d+' | head -1)
+if [ "$java_version" -lt 17 ]; then
+    echo "❌ 错误: 需要 Java 17 或更高版本，当前版本: $java_version"
+    exit 1
+fi
+
+echo "✅ Java 版本检查通过: $java_version"
+
+# 清理并构建
+echo "🧹 清理旧文件..."
+./mvnw clean
+
+echo "📦 构建项目..."
+./mvnw package -DskipTests
+
+if [ $? -eq 0 ]; then
+    echo "✅ 构建成功！"
+    echo ""
+    echo "📋 使用说明:"
+    echo "java -jar target/mcp-starter-default-client-0.0.1-SNAPSHOT.jar --token=YOUR_DOCUMENT_TOKEN"
+    echo ""
+    echo "📖 详细说明请查看 MVP_README.md"
+else
+    echo "❌ 构建失败！请检查错误信息。"
+    exit 1
+fi 

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,12 @@
 			<artifactId>spring-ai-starter-mcp-client</artifactId>
 		</dependency>
 
+		<!-- Spring Web (v0.2版本启用REST API) -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-starter-model-openai</artifactId>
@@ -49,6 +55,32 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-starter-model-anthropic</artifactId>
 		</dependency> -->
+
+		<!-- Spring Retry -->
+		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+		</dependency>
+
+		<!-- Resilience4j 断路器 -->
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-spring-boot3</artifactId>
+			<version>2.1.0</version>
+		</dependency>
+
+		<!-- Spring AOP (Retry 和 Async 需要) -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-aop</artifactId>
+		</dependency>
+
+		<!-- Lombok for easier development -->
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
 
 	</dependencies>
 
@@ -67,6 +99,21 @@
 					<image>
 						<builder>paketobuildpacks/builder-jammy-tiny:latest</builder>
 					</image>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.13.0</version>
+				<configuration>
+					<release>17</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.38</version>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/org/springframework/ai/mcp/samples/client/Application.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/Application.java
@@ -15,52 +15,158 @@
  */
 package org.springframework.ai.mcp.samples.client;
 
-import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.ChatClient.ChatClientRequestSpec;
-import org.springframework.ai.tool.ToolCallbackProvider;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.mcp.samples.client.watch.DocWatchManager;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
+@Slf4j
 public class Application {
 
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
 	}
 
-	@Value("${ai.user.input}")
-	private String userInput;
-
+	/**
+	 * v0.2版本：支持CLI和Web双模式
+	 * - CLI模式：提供--token参数时，直接启动监听
+	 * - Web模式：不提供参数时，启动Web服务器等待REST API调用
+	 */
 	@Bean
-	public CommandLineRunner predefinedQuestions(ChatClient.Builder chatClientBuilder, ToolCallbackProvider tools,
-			ConfigurableApplicationContext context) {
-		// 打印可用工具信息
-		System.out.println("Available tools:");
-		for (int i = 0; i < tools.getToolCallbacks().length; i++) {
-			System.out.println(i + ": " + tools.getToolCallbacks()[i].getToolDefinition().name());
-			System.out.println("   Schema: " + tools.getToolCallbacks()[i].getToolDefinition().inputSchema());
-		}
-		
+	public CommandLineRunner documentWatchRunner(DocWatchManager watchManager) {
 		return args -> {
-			var chatClient = chatClientBuilder
-					.defaultToolCallbacks(tools)
-					.build();
-
-			System.out.println("\n>>> QUESTION: " + userInput);
+			log.info("=== Feicur 文档监听助手 v0.2 启动 ===");
 			
-			// 创建请求并打印详细信息
-			ChatClientRequestSpec prompt = chatClient.prompt(userInput);
-			var response = prompt.call();
+			String docToken = extractDocTokenFromArgs(args);
 			
-			// System.out.println("\n>>> COMPLETE RESPONSE: ");
-			// System.out.println(response.chatClientResponse().chatResponse().toString());
-			System.out.println("\n>>> ASSISTANT CONTENT: " + response.content());
-
-			context.close();
+			if (docToken != null && !docToken.trim().isEmpty()) {
+				// CLI模式：有token参数，直接启动监听
+				startCliMode(watchManager, docToken);
+			} else {
+				// Web模式：无token参数，启动Web服务器
+				startWebMode();
+			}
 		};
+	}
+	
+	/**
+	 * 启动CLI模式
+	 */
+	private void startCliMode(DocWatchManager watchManager, String docToken) {
+		log.info("🖥️  CLI模式启动");
+		log.info("从命令行参数读取到文档token: {}", docToken);
+		
+		try {
+			// 启动文档监听
+			watchManager.startWatching(docToken);
+			
+			log.info("✅ 文档监听已启动");
+			log.info("🔍 正在监听文档评论变更...");
+			log.info("📝 检测到的指令将会在控制台显示");
+			log.info("🌐 同时提供REST API服务: http://localhost:7777");
+			log.info("⏸️  按 Ctrl+C 停止监听");
+			
+			// 保持应用运行，等待定时任务执行
+			keepApplicationRunning();
+			
+		} catch (Exception e) {
+			log.error("启动文档监听失败", e);
+			System.exit(1);
+		}
+	}
+	
+	/**
+	 * 启动Web模式
+	 */
+	private void startWebMode() {
+		log.info("🌐 Web模式启动");
+		log.info("✅ REST API服务已启动: http://localhost:7777");
+		log.info("");
+		log.info("📋 可用端点:");
+		log.info("  🔗 启动监听: http://localhost:7777/watch?url=<飞书文档URL>");
+		log.info("  📊 查看状态: http://localhost:7777/status");
+		log.info("  ❤️  健康检查: http://localhost:7777/health");
+		log.info("");
+		log.info("💡 使用方式:");
+		log.info("  在飞书文档地址前加上: http://localhost:7777/watch?url=");
+		log.info("  例如: http://localhost:7777/watch?url=https://example.feishu.cn/docx/xxx");
+		log.info("");
+		log.info("🔧 API管理:");
+		log.info("  停止监听: curl -X DELETE http://localhost:7777/watch/<token>");
+		log.info("");
+		log.info("⏸️  按 Ctrl+C 停止服务");
+		
+		// Web模式下不需要额外的等待，Spring Boot会保持应用运行
+		setupShutdownHook();
+	}
+	
+	/**
+	 * 从命令行参数中提取文档token
+	 */
+	private String extractDocTokenFromArgs(String[] args) {
+		for (String arg : args) {
+			if (arg.startsWith("--token=")) {
+				return arg.substring("--token=".length()).trim();
+			}
+		}
+		return null;
+	}
+	
+	/**
+	 * 打印使用说明
+	 */
+	private void printUsage() {
+		System.out.println("\n📖 Feicur v0.2 使用说明:");
+		System.out.println("");
+		System.out.println("🖥️  CLI模式（直接启动监听）:");
+		System.out.println("java -jar feicur.jar --token=YOUR_DOCUMENT_TOKEN");
+		System.out.println("");
+		System.out.println("🌐 Web模式（REST API服务）:");
+		System.out.println("java -jar feicur.jar");
+		System.out.println("然后访问: http://localhost:7777/watch?url=<飞书文档URL>");
+		System.out.println("");
+		System.out.println("参数说明:");
+		System.out.println("  --token=<文档token>  要监听的飞书文档token（可选）");
+		System.out.println("");
+		System.out.println("示例:");
+		System.out.println("  CLI: java -jar feicur.jar --token=doccnXeWNhHv42eBdRUd6mh0vdb");
+		System.out.println("  Web: http://localhost:7777/watch?url=https://example.feishu.cn/docx/doccnXeWNhHv42eBdRUd6mh0vdb");
+		System.out.println("");
+		System.out.println("💡 提示:");
+		System.out.println("  - 确保MCP服务器正在运行（http://localhost:8788）");
+		System.out.println("  - Web模式支持同时监听多个文档");
+		System.out.println("");
+	}
+	
+	/**
+	 * 保持应用运行（CLI模式）
+	 */
+	private void keepApplicationRunning() {
+		setupShutdownHook();
+		
+		// 使用简单的无限循环保持应用运行
+		// Spring的定时任务会在后台执行
+		try {
+			Object lock = new Object();
+			synchronized (lock) {
+				lock.wait(); // 永久等待，直到应用被中断
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			log.info("应用被中断，正在退出...");
+		}
+	}
+	
+	/**
+	 * 设置关闭钩子
+	 */
+	private void setupShutdownHook() {
+		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+			log.info("\n🛑 正在停止Feicur服务...");
+			log.info("👋 Feicur已退出，感谢使用！");
+		}));
 	}
 }

--- a/src/main/java/org/springframework/ai/mcp/samples/client/api/FeishuApi.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/api/FeishuApi.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.api;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.mcp.samples.client.model.RawComment;
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * 飞书API调用封装
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FeishuApi {
+    
+    private final ToolCallbackProvider toolCallbackProvider;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    
+    /**
+     * 获取文档评论列表
+     */
+    @Retryable(
+        value = {Exception.class},
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    @CircuitBreaker(name = "feishu-api", fallbackMethod = "listCommentsFallback")
+    public List<RawComment> listComments(String token) {
+        log.debug("Fetching comments for doc: {}", token);
+        try {
+            // 查找正确的飞书评论工具
+            ToolCallback feishuTool = findFeishuCommentsToolCallback();
+            if (feishuTool == null) {
+                log.warn("No mcp_feishu_driveV1FileCommentList tool found, returning empty list");
+                return Collections.emptyList();
+            }
+            
+            // 构建正确的请求参数结构
+            var request = Map.of(
+                "path", Map.of("file_token", token),
+                "params", Map.of(
+                    "file_type", "docx",
+                    "page_size", 50,
+                    "user_id_type", "open_id"
+                ),
+                "useUAT", true
+            );
+            var response = feishuTool.call(objectMapper.writeValueAsString(request));
+            
+            log.debug("MCP tool response: {}", response);
+            return parseCommentsResponse(response);
+            
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize request for doc: {}", token, e);
+            throw new RuntimeException("JSON processing error", e);
+        } catch (Exception e) {
+            log.error("Failed to fetch comments for doc: {}", token, e);
+            throw e;
+        }
+    }
+    
+    /**
+     * 断路器降级方法
+     */
+    public List<RawComment> listCommentsFallback(String token, Exception ex) {
+        log.warn("Circuit breaker activated for doc: {}, returning empty list. Error: {}", 
+                token, ex.getMessage());
+        return Collections.emptyList();
+    }
+    
+    /**
+     * 查找飞书评论工具回调
+     */
+    private ToolCallback findFeishuCommentsToolCallback() {
+        ToolCallback[] callbacks = toolCallbackProvider.getToolCallbacks();
+        for (ToolCallback callback : callbacks) {
+            String toolName = callback.getToolDefinition().name();
+            if ("spring_ai_mcp_client_feishu_driveV1FileCommentList".equals(toolName)) {
+                return callback;
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * 解析MCP响应为RawComment列表
+     */
+    private List<RawComment> parseCommentsResponse(String response) {
+        try {
+            if (response == null || response.trim().isEmpty()) {
+                log.warn("Received empty response from MCP tool");
+                return Collections.emptyList();
+            }
+            
+            // 先打印完整的响应内容进行调试
+            log.debug("Raw MCP response: {}", response);
+            
+            // 将响应转换为JSON节点进行解析
+            JsonNode jsonNode = objectMapper.readTree(response);
+            log.debug("Parsed JSON response: {}", jsonNode);
+            
+            // MCP工具返回的格式是数组，需要先提取出实际的响应内容
+            final JsonNode actualResponse;
+            if (jsonNode.isArray() && jsonNode.size() > 0) {
+                JsonNode firstElement = jsonNode.get(0);
+                if (firstElement.has("text")) {
+                    String textContent = firstElement.get("text").asText();
+                    log.debug("Extracted text content: {}", textContent);
+                    
+                    // 解析 "Success: {...}" 格式
+                    if (textContent.startsWith("Success: ")) {
+                        String actualJsonString = textContent.substring("Success: ".length());
+                        actualResponse = objectMapper.readTree(actualJsonString);
+                        log.debug("Parsed actual response: {}", actualResponse);
+                    } else {
+                        actualResponse = null;
+                    }
+                } else {
+                    actualResponse = null;
+                }
+            } else {
+                actualResponse = null;
+            }
+            
+            if (actualResponse == null) {
+                log.warn("Could not extract actual response from MCP format");
+                return Collections.emptyList();
+            }
+            
+            // 打印响应的所有顶级字段
+            actualResponse.fieldNames().forEachRemaining(fieldName -> {
+                log.debug("Response field: {} = {}", fieldName, actualResponse.get(fieldName));
+            });
+            
+            // 根据飞书API的实际响应结构进行解析
+            List<RawComment> comments = new ArrayList<>();
+            
+            // 飞书API返回的结构有 items 字段
+            if (actualResponse.has("items")) {
+                JsonNode itemsNode = actualResponse.get("items");
+                log.debug("Found items node: {}", itemsNode);
+                if (itemsNode.isArray()) {
+                    log.debug("Items is array with {} elements", itemsNode.size());
+                    for (JsonNode commentNode : itemsNode) {
+                        log.debug("Processing comment node: {}", commentNode);
+                        RawComment comment = parseCommentNode(commentNode);
+                        if (comment != null) {
+                            comments.add(comment);
+                        }
+                    }
+                } else {
+                    log.warn("Items node is not an array: {}", itemsNode);
+                }
+            } else {
+                log.warn("No 'items' field found in response. Available fields: {}", 
+                    actualResponse.fieldNames());
+                // 尝试检查其他可能的字段名
+                if (actualResponse.has("data")) {
+                    log.debug("Found 'data' field: {}", actualResponse.get("data"));
+                    JsonNode dataNode = actualResponse.get("data");
+                    if (dataNode.has("items")) {
+                        log.debug("Found items in data: {}", dataNode.get("items"));
+                    }
+                }
+            }
+            
+            log.debug("Parsed {} comments from response", comments.size());
+            return comments;
+            
+        } catch (Exception e) {
+            log.error("Failed to parse comments response: {}", response, e);
+            return Collections.emptyList();
+        }
+    }
+    
+    /**
+     * 解析单个评论节点
+     */
+    private RawComment parseCommentNode(JsonNode commentNode) {
+        try {
+            RawComment comment = new RawComment();
+            
+            // 基础字段
+            comment.setCommentId(getStringValue(commentNode, "comment_id"));
+            comment.setAuthorId(getStringValue(commentNode, "user_id"));
+            comment.setPosition(getStringValue(commentNode, "quote")); // 使用 quote 作为位置信息
+            
+            // 从 reply_list 中提取评论内容
+            String content = extractCommentContent(commentNode);
+            comment.setContent(content);
+            
+            // 时间字段解析 - 飞书返回的是 Unix 时间戳（秒）
+            comment.setCreateTime(parseUnixTimestamp(commentNode, "create_time"));
+            comment.setUpdateTime(parseUnixTimestamp(commentNode, "update_time"));
+            
+            // 布尔字段 - 飞书使用 is_solved
+            comment.setIsResolved(getBooleanValue(commentNode, "is_solved"));
+            
+            return comment;
+            
+        } catch (Exception e) {
+            log.warn("Failed to parse comment node: {}", commentNode, e);
+            return null;
+        }
+    }
+    
+    /**
+     * 从 reply_list 中提取评论内容
+     */
+    private String extractCommentContent(JsonNode commentNode) {
+        JsonNode replyList = commentNode.get("reply_list");
+        if (replyList != null && replyList.has("replies")) {
+            JsonNode replies = replyList.get("replies");
+            if (replies.isArray() && replies.size() > 0) {
+                JsonNode firstReply = replies.get(0);
+                JsonNode content = firstReply.get("content");
+                if (content != null && content.has("elements")) {
+                    JsonNode elements = content.get("elements");
+                    if (elements.isArray() && elements.size() > 0) {
+                        JsonNode firstElement = elements.get(0);
+                        if (firstElement.has("text_run")) {
+                            JsonNode textRun = firstElement.get("text_run");
+                            if (textRun.has("text")) {
+                                return textRun.get("text").asText();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * 获取字符串值，支持多个可能的字段名
+     */
+    private String getStringValue(JsonNode node, String... fieldNames) {
+        for (String fieldName : fieldNames) {
+            JsonNode field = node.get(fieldName);
+            if (field != null && !field.isNull()) {
+                return field.asText();
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * 获取布尔值
+     */
+    private Boolean getBooleanValue(JsonNode node, String... fieldNames) {
+        for (String fieldName : fieldNames) {
+            JsonNode field = node.get(fieldName);
+            if (field != null && !field.isNull()) {
+                if (field.isBoolean()) {
+                    return field.asBoolean();
+                } else if (field.isTextual()) {
+                    String text = field.asText().toLowerCase();
+                    return "true".equals(text) || "resolved".equals(text) || "1".equals(text);
+                }
+            }
+        }
+        return false;
+    }
+    
+    /**
+     * 解析 Unix 时间戳字段
+     */
+    private Instant parseUnixTimestamp(JsonNode node, String... fieldNames) {
+        for (String fieldName : fieldNames) {
+            JsonNode field = node.get(fieldName);
+            if (field != null && !field.isNull()) {
+                try {
+                    long timestamp = field.asLong();
+                    if (timestamp > 0) {
+                        return Instant.ofEpochSecond(timestamp);
+                    }
+                } catch (Exception e) {
+                    log.debug("Failed to parse timestamp field {}: {}", fieldName, field.asText());
+                }
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * 解析时间字段（保留原方法以兼容其他可能的时间格式）
+     */
+    private Instant parseTimeField(JsonNode node, String... fieldNames) {
+        for (String fieldName : fieldNames) {
+            JsonNode field = node.get(fieldName);
+            if (field != null && !field.isNull()) {
+                try {
+                    String timeStr = field.asText();
+                    if (timeStr != null && !timeStr.isEmpty()) {
+                        // 尝试不同的时间格式
+                        return Instant.parse(timeStr);
+                    }
+                } catch (Exception e) {
+                    log.debug("Failed to parse time field {}: {}", fieldName, field.asText());
+                }
+            }
+        }
+        return null;
+    }
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/config/FeicurConfig.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/config/FeicurConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Feicur应用配置类
+ */
+@Configuration
+@EnableRetry
+@EnableAsync
+@EnableScheduling
+public class FeicurConfig {
+    
+    /**
+     * 任务调度器配置
+     * 用于@Scheduled定时任务
+     */
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5); // 限制并发 DocWatcher 数量
+        scheduler.setThreadNamePrefix("doc-watcher-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+        scheduler.initialize();
+        return scheduler;
+    }
+    
+    /**
+     * 异步任务执行器配置
+     * 用于@Async异步方法
+     */
+    @Bean
+    public Executor asyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("event-handler-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+        executor.initialize();
+        return executor;
+    }
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/controller/WatchController.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/controller/WatchController.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.mcp.samples.client.watch.DocWatchManager;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * v0.2版本 REST API 控制器
+ * 实现重定向模式的文档监听功能
+ */
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@CrossOrigin(origins = "*") // 允许跨域请求
+public class WatchController {
+    
+    private final DocWatchManager watchManager;
+    
+    // 飞书文档URL正则表达式
+    private static final Pattern FEISHU_URL_PATTERN = 
+            Pattern.compile(".*feishu\\.cn/(?:docx?|docs)/([a-zA-Z0-9]+)");
+    
+    /**
+     * 启动文档监听并重定向到原始飞书文档
+     * 
+     * @param feishuDocUrl 飞书文档完整URL
+     * @return 302重定向响应
+     */
+    @GetMapping("/watch")
+    public ResponseEntity<Void> startWatchingAndRedirect(
+            @RequestParam("url") String feishuDocUrl) {
+        
+        try {
+            log.info("接收到监听请求，文档URL: {}", feishuDocUrl);
+            
+            // 1. 解析飞书文档URL，提取token
+            String docToken = extractTokenFromFeishuUrl(feishuDocUrl);
+            log.info("解析到文档token: {}", docToken);
+            
+            // 2. 启动文档监听
+            watchManager.startWatching(docToken);
+            log.info("✅ 已启动文档监听: {}", docToken);
+            
+            // 3. 重定向到原始飞书文档
+            return ResponseEntity.status(HttpStatus.FOUND)
+                    .location(URI.create(feishuDocUrl))
+                    .build();
+                    
+        } catch (IllegalArgumentException e) {
+            log.error("❌ URL解析失败: {}", e.getMessage());
+            return ResponseEntity.badRequest().build();
+        } catch (Exception e) {
+            log.error("❌ 启动监听失败", e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+    
+    /**
+     * 停止监听指定文档
+     * 
+     * @param token 文档token
+     * @return JSON响应
+     */
+    @DeleteMapping("/watch/{token}")
+    public ResponseEntity<Map<String, Object>> stopWatching(
+            @PathVariable String token) {
+        
+        try {
+            log.info("接收到停止监听请求，文档token: {}", token);
+            
+            boolean wasWatching = watchManager.isWatching(token);
+            watchManager.stopWatching(token);
+            
+            String message = wasWatching ? 
+                "已停止监听文档: " + token : 
+                "文档未在监听中: " + token;
+                
+            log.info("✅ {}", message);
+            
+            return ResponseEntity.ok(Map.of(
+                "success", true,
+                "message", message,
+                "token", token,
+                "wasWatching", wasWatching
+            ));
+            
+        } catch (Exception e) {
+            log.error("❌ 停止监听失败", e);
+            return ResponseEntity.ok(Map.of(
+                "success", false,
+                "message", "停止监听失败: " + e.getMessage(),
+                "token", token
+            ));
+        }
+    }
+    
+    /**
+     * 查看当前监听状态
+     * 
+     * @return JSON状态信息
+     */
+    @GetMapping("/status")
+    public ResponseEntity<Map<String, Object>> getStatus() {
+        
+        try {
+            Map<String, Object> status = watchManager.getWatcherStatus();
+            log.debug("查询监听状态: {}", status);
+            
+            return ResponseEntity.ok(status);
+            
+        } catch (Exception e) {
+            log.error("❌ 获取状态失败", e);
+            return ResponseEntity.ok(Map.of(
+                "success", false,
+                "message", "获取状态失败: " + e.getMessage()
+            ));
+        }
+    }
+    
+    /**
+     * 健康检查端点
+     * 
+     * @return 服务状态
+     */
+    @GetMapping("/health")
+    public ResponseEntity<Map<String, Object>> health() {
+        return ResponseEntity.ok(Map.of(
+            "status", "UP",
+            "service", "Feicur Document Watcher",
+            "version", "v0.2",
+            "timestamp", System.currentTimeMillis()
+        ));
+    }
+    
+    /**
+     * 从飞书文档URL中提取文档token
+     * 
+     * @param url 飞书文档URL
+     * @return 文档token
+     * @throws IllegalArgumentException 如果URL格式无效
+     */
+    private String extractTokenFromFeishuUrl(String url) {
+        if (url == null || url.trim().isEmpty()) {
+            throw new IllegalArgumentException("文档URL不能为空");
+        }
+        
+        // 支持各种飞书文档URL格式：
+        // https://xxx.feishu.cn/docx/doccnXeWNhHv42eBdRUd6mh0vdb
+        // https://xxx.feishu.cn/docs/doccnXeWNhHv42eBdRUd6mh0vdb
+        // https://xxx.feishu.cn/doc/doccnXeWNhHv42eBdRUd6mh0vdb
+        
+        Matcher matcher = FEISHU_URL_PATTERN.matcher(url);
+        
+        if (matcher.find()) {
+            String token = matcher.group(1);
+            log.debug("从URL {} 解析到token: {}", url, token);
+            return token;
+        }
+        
+        throw new IllegalArgumentException("无效的飞书文档URL格式。" +
+                "期望格式: https://xxx.feishu.cn/docx/token 或 https://xxx.feishu.cn/docs/token。" +
+                "实际URL: " + url);
+    }
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/diff/CommentEventDetector.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/diff/CommentEventDetector.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.diff;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.mcp.samples.client.model.CommentEvent;
+import org.springframework.ai.mcp.samples.client.model.RawComment;
+import org.springframework.ai.mcp.samples.client.watch.snapshot.CommentSnapshot;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * 评论变更事件检测器
+ */
+@Component
+@Slf4j
+public class CommentEventDetector {
+    
+    /**
+     * 检测两个快照之间的差异，生成事件列表
+     * 
+     * @param oldSnapshot 旧快照（可以为null，表示第一次）
+     * @param newSnapshot 新快照
+     * @return 变更事件列表
+     */
+    public List<CommentEvent> detectChanges(CommentSnapshot oldSnapshot, CommentSnapshot newSnapshot) {
+        List<CommentEvent> events = new ArrayList<>();
+        
+        if (newSnapshot == null) {
+            log.warn("New snapshot is null, no events to detect");
+            return events;
+        }
+        
+        Map<String, RawComment> newComments = newSnapshot.getCommentMap();
+        if (newComments == null) {
+            log.debug("New snapshot has no comments");
+            return events;
+        }
+        
+        // 如果是第一次快照，忽略所有评论（不生成新增事件）
+        if (oldSnapshot == null) {
+            log.info("First snapshot detected, ignoring all {} comments (no events generated)", newComments.size());
+            return events; // 返回空的事件列表
+        }
+        
+        Map<String, RawComment> oldComments = oldSnapshot.getCommentMap();
+        if (oldComments == null) {
+            oldComments = new HashMap<>();
+        }
+        
+        // 检测新增和修改的评论
+        for (Map.Entry<String, RawComment> entry : newComments.entrySet()) {
+            String commentId = entry.getKey();
+            RawComment newComment = entry.getValue();
+            RawComment oldComment = oldComments.get(commentId);
+            
+            if (oldComment == null) {
+                // 新增评论
+                events.add(new CommentEvent(CommentEvent.Type.NEW, newComment, "新增评论"));
+                log.debug("Detected new comment: {}", commentId);
+            } else {
+                // 检查是否有修改
+                CommentEvent changeEvent = detectCommentChange(oldComment, newComment);
+                if (changeEvent != null) {
+                    events.add(changeEvent);
+                    log.debug("Detected comment change: {} - {}", commentId, changeEvent.getType());
+                }
+            }
+        }
+        
+        // 检测删除的评论
+        for (String oldCommentId : oldComments.keySet()) {
+            if (!newComments.containsKey(oldCommentId)) {
+                // 评论被删除
+                RawComment deletedComment = oldComments.get(oldCommentId);
+                events.add(new CommentEvent(CommentEvent.Type.DELETE, deletedComment, "评论被删除"));
+                log.debug("Detected deleted comment: {}", oldCommentId);
+            }
+        }
+        
+        log.debug("Detected {} change events", events.size());
+        return events;
+    }
+    
+    /**
+     * 检测单个评论的变更
+     */
+    private CommentEvent detectCommentChange(RawComment oldComment, RawComment newComment) {
+        // 检查更新时间（幂等检查）
+        if (isUpdateTimeEqual(oldComment.getUpdateTime(), newComment.getUpdateTime())) {
+            return null; // 没有变更
+        }
+        
+        // 检查解决状态变更
+        if (!Objects.equals(oldComment.getIsResolved(), newComment.getIsResolved())) {
+            if (Boolean.TRUE.equals(newComment.getIsResolved())) {
+                return new CommentEvent(CommentEvent.Type.RESOLVE, newComment, "评论被解决");
+            } else {
+                return new CommentEvent(CommentEvent.Type.UNRESOLVE, newComment, "评论重新打开");
+            }
+        }
+        
+        // 检查内容变更
+        if (!Objects.equals(oldComment.getContent(), newComment.getContent())) {
+            return new CommentEvent(CommentEvent.Type.EDIT, newComment, "评论内容被修改");
+        }
+        
+        // 检查其他字段变更（作者、位置等）
+        if (hasOtherChanges(oldComment, newComment)) {
+            return new CommentEvent(CommentEvent.Type.EDIT, newComment, "评论信息被修改");
+        }
+        
+        return null;
+    }
+    
+    /**
+     * 检查更新时间是否相等（考虑精度问题）
+     */
+    private boolean isUpdateTimeEqual(Instant time1, Instant time2) {
+        if (time1 == null && time2 == null) {
+            return true;
+        }
+        if (time1 == null || time2 == null) {
+            return false;
+        }
+        // 允许1秒的误差
+        return Math.abs(time1.getEpochSecond() - time2.getEpochSecond()) <= 1;
+    }
+    
+    /**
+     * 检查其他字段是否有变更
+     */
+    private boolean hasOtherChanges(RawComment oldComment, RawComment newComment) {
+        return !Objects.equals(oldComment.getAuthorId(), newComment.getAuthorId()) ||
+               !Objects.equals(oldComment.getAuthorName(), newComment.getAuthorName()) ||
+               !Objects.equals(oldComment.getParentId(), newComment.getParentId()) ||
+               !Objects.equals(oldComment.getPosition(), newComment.getPosition());
+    }
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/event/CommentChangeEvent.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/event/CommentChangeEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.event;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import org.springframework.ai.mcp.samples.client.model.CommentEvent;
+import org.springframework.ai.mcp.samples.client.model.RawComment;
+import java.time.Instant;
+
+/**
+ * 评论变更事件（用于Spring事件总线）
+ */
+@Data
+@AllArgsConstructor
+public class CommentChangeEvent {
+    
+    /**
+     * 文档Token
+     */
+    private final String docToken;
+    
+    /**
+     * 事件类型
+     */
+    private final CommentEvent.Type eventType;
+    
+    /**
+     * 评论数据
+     */
+    private final RawComment comment;
+    
+    /**
+     * 事件时间戳
+     */
+    private final Instant timestamp;
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/event/CommentEventListener.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/event/CommentEventListener.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.mcp.samples.client.model.CommentEvent;
+import org.springframework.ai.mcp.samples.client.model.UserCommand;
+import org.springframework.ai.mcp.samples.client.queue.CommandQueue;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ * 评论事件监听器
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CommentEventListener {
+    
+    private final CommandQueue commandQueue;
+    
+    /**
+     * 处理评论变更事件
+     */
+    @EventListener
+    @Async
+    public void handleCommentChange(CommentChangeEvent event) {
+        log.info("Processing comment change: {} for doc: {}", 
+                 event.getEventType(), event.getDocToken());
+        
+        var command = mapEventToCommand(event);
+        if (command != null) {
+            command.setDocToken(event.getDocToken());
+            boolean success = commandQueue.offer(command);
+            if (success) {
+                log.info("Successfully queued command: {}", command.getCommandType());
+            } else {
+                log.warn("Failed to queue command: {}, queue might be full", command.getCommandType());
+            }
+        } else {
+            log.debug("No command mapping for event type: {}", event.getEventType());
+        }
+    }
+    
+    /**
+     * 事件到指令的映射逻辑
+     */
+    private UserCommand mapEventToCommand(CommentChangeEvent event) {
+        return switch (event.getEventType()) {
+            case NEW -> new UserCommand("ADD_REQUIREMENT", event.getComment());
+            case EDIT -> new UserCommand("UPDATE_REQUIREMENT", event.getComment());
+            case DELETE -> new UserCommand("REMOVE_REQUIREMENT", event.getComment());
+            case RESOLVE -> new UserCommand("RESOLVE_REQUIREMENT", event.getComment());
+            case UNRESOLVE -> new UserCommand("REOPEN_REQUIREMENT", event.getComment());
+            default -> {
+                log.warn("Unknown event type: {}", event.getEventType());
+                yield null;
+            }
+        };
+    }
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/event/CommentEventPublisher.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/event/CommentEventPublisher.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.mcp.samples.client.model.CommentEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import java.time.Instant;
+
+/**
+ * 评论事件发布器
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CommentEventPublisher {
+    
+    private final ApplicationEventPublisher eventPublisher;
+    
+    /**
+     * 发布评论变更事件
+     */
+    public void publishCommentChange(String docToken, CommentEvent event) {
+        log.debug("Publishing comment change event: {} for doc: {}", event.getType(), docToken);
+        
+        var changeEvent = new CommentChangeEvent(
+            docToken, 
+            event.getType(), 
+            event.getComment(),
+            Instant.now()
+        );
+        
+        eventPublisher.publishEvent(changeEvent);
+        
+        log.info("Published comment {} event for comment ID: {} in doc: {}", 
+                event.getType().getDescription(), 
+                event.getComment().getCommentId(), 
+                docToken);
+    }
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/executor/CommandExecutor.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/executor/CommandExecutor.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.executor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.mcp.samples.client.model.UserCommand;
+import org.springframework.ai.mcp.samples.client.queue.CommandQueue;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 指令执行器 - 定时消费队列中的指令
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CommandExecutor {
+    
+    private final CommandQueue commandQueue;
+    
+    @Value("${feicur.execute.interval:3000}")
+    private long executeInterval;
+    
+    /**
+     * 定时执行指令消费
+     * 使用fixedDelayString从配置文件读取间隔
+     */
+    @Scheduled(fixedDelayString = "${feicur.execute.interval:3000}")
+    public void executeCommands() {
+        try {
+            // 使用poll避免无限阻塞，超时时间设为执行间隔的一半
+            UserCommand command = commandQueue.poll(executeInterval / 2, TimeUnit.MILLISECONDS);
+            
+            if (command != null) {
+                executeCommand(command);
+            } else {
+                log.debug("No commands in queue, continuing...");
+            }
+            
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Command execution interrupted", e);
+        } catch (Exception e) {
+            log.error("Error occurred while executing commands", e);
+        }
+    }
+    
+    /**
+     * 执行单个指令（MVP版本只打印）
+     */
+    private void executeCommand(UserCommand command) {
+        log.info("=== 执行指令 ===");
+        log.info("指令类型: {}", command.getCommandType());
+        log.info("文档Token: {}", command.getDocToken());
+        log.info("时间戳: {}", command.getTimestamp());
+        log.info("指令内容: {}", command.getContent());
+        
+        if (command.getSourceComment() != null) {
+            log.info("评论详情:");
+            log.info("  - 评论ID: {}", command.getSourceComment().getCommentId());
+            log.info("  - 作者: {}", command.getSourceComment().getAuthorName());
+            log.info("  - 创建时间: {}", command.getSourceComment().getCreateTime());
+            log.info("  - 更新时间: {}", command.getSourceComment().getUpdateTime());
+            log.info("  - 是否已解决: {}", command.getSourceComment().getIsResolved());
+        }
+        
+        log.info("===============");
+        
+        // 在控制台也打印便于观察
+        System.out.println("\n🔔 新指令: " + command.getFormattedDescription());
+        System.out.println("📄 文档: " + command.getDocToken());
+        System.out.println("👤 作者: " + (command.getSourceComment() != null ? 
+                          command.getSourceComment().getAuthorName() : "未知"));
+        System.out.println("💬 内容: " + (command.getContent() != null ? 
+                          command.getContent().substring(0, Math.min(100, command.getContent().length())) : "无内容"));
+        System.out.println("----------------------------------------\n");
+    }
+    
+    /**
+     * 获取队列状态信息
+     */
+    @Scheduled(fixedDelay = 30000) // 每30秒打印一次队列状态
+    public void printQueueStatus() {
+        int queueSize = commandQueue.size();
+        if (queueSize > 0) {
+            log.info("当前队列中有 {} 个待执行指令", queueSize);
+        }
+    }
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/model/CommentEvent.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/model/CommentEvent.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.model;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+/**
+ * 评论变更事件
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentEvent {
+    
+    /**
+     * 事件类型枚举
+     */
+    public enum Type {
+        NEW("新增"),
+        EDIT("编辑"),
+        DELETE("删除"),
+        RESOLVE("解决"),
+        UNRESOLVE("重新打开");
+        
+        private final String description;
+        
+        Type(String description) {
+            this.description = description;
+        }
+        
+        public String getDescription() {
+            return description;
+        }
+    }
+    
+    /**
+     * 事件类型
+     */
+    private Type type;
+    
+    /**
+     * 相关的评论数据
+     */
+    private RawComment comment;
+    
+    /**
+     * 事件描述（可选）
+     */
+    private String description;
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/model/RawComment.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/model/RawComment.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.model;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import java.time.Instant;
+
+/**
+ * 飞书文档评论的原始数据模型
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RawComment {
+    
+    /**
+     * 评论ID
+     */
+    private String commentId;
+    
+    /**
+     * 评论内容
+     */
+    private String content;
+    
+    /**
+     * 评论作者ID
+     */
+    private String authorId;
+    
+    /**
+     * 评论作者名称
+     */
+    private String authorName;
+    
+    /**
+     * 创建时间
+     */
+    private Instant createTime;
+    
+    /**
+     * 更新时间
+     */
+    private Instant updateTime;
+    
+    /**
+     * 是否已解决
+     */
+    private Boolean isResolved;
+    
+    /**
+     * 父评论ID（回复场景）
+     */
+    private String parentId;
+    
+    /**
+     * 评论位置信息
+     */
+    private String position;
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/model/UserCommand.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/model/UserCommand.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.model;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import java.time.Instant;
+
+/**
+ * 用户指令模型
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserCommand {
+    
+    /**
+     * 指令类型
+     */
+    private String commandType;
+    
+    /**
+     * 指令内容
+     */
+    private String content;
+    
+    /**
+     * 原始评论数据
+     */
+    private RawComment sourceComment;
+    
+    /**
+     * 指令创建时间
+     */
+    private Instant timestamp;
+    
+    /**
+     * 文档token
+     */
+    private String docToken;
+    
+    /**
+     * 构造函数，自动设置时间戳
+     */
+    public UserCommand(String commandType, RawComment sourceComment) {
+        this.commandType = commandType;
+        this.sourceComment = sourceComment;
+        this.timestamp = Instant.now();
+        if (sourceComment != null) {
+            this.content = sourceComment.getContent();
+        }
+    }
+    
+    /**
+     * 获取格式化的指令描述
+     */
+    public String getFormattedDescription() {
+        return String.format("[%s] %s - %s", 
+            commandType, 
+            timestamp,
+            content != null ? content.substring(0, Math.min(50, content.length())) + "..." : "无内容"
+        );
+    }
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/queue/CommandQueue.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/queue/CommandQueue.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.queue;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.mcp.samples.client.model.UserCommand;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 指令队列封装类
+ */
+@Component
+@Slf4j
+public class CommandQueue {
+    
+    private final BlockingQueue<UserCommand> queue;
+    
+    public CommandQueue() {
+        // 创建容量为1000的有界队列
+        this.queue = new LinkedBlockingQueue<>(1000);
+        log.info("Command queue initialized with capacity: 1000");
+    }
+    
+    /**
+     * 非阻塞添加指令到队列
+     * 
+     * @param command 用户指令
+     * @return 成功返回true，队列满返回false
+     */
+    public boolean offer(UserCommand command) {
+        boolean success = queue.offer(command);
+        if (success) {
+            log.debug("Command offered to queue: {}", command.getCommandType());
+        } else {
+            log.warn("Failed to offer command to queue, queue is full. Command: {}", command.getCommandType());
+        }
+        return success;
+    }
+    
+    /**
+     * 阻塞获取队列中的指令
+     * 
+     * @return 用户指令，如果队列为空则阻塞等待
+     * @throws InterruptedException 如果等待被中断
+     */
+    public UserCommand take() throws InterruptedException {
+        UserCommand command = queue.take();
+        log.debug("Command taken from queue: {}", command.getCommandType());
+        return command;
+    }
+    
+    /**
+     * 带超时的获取队列中的指令
+     * 
+     * @param timeout 超时时间
+     * @param unit 时间单位
+     * @return 用户指令，如果超时返回null
+     * @throws InterruptedException 如果等待被中断
+     */
+    public UserCommand poll(long timeout, TimeUnit unit) throws InterruptedException {
+        UserCommand command = queue.poll(timeout, unit);
+        if (command != null) {
+            log.debug("Command polled from queue: {}", command.getCommandType());
+        }
+        return command;
+    }
+    
+    /**
+     * 获取队列当前大小
+     */
+    public int size() {
+        return queue.size();
+    }
+    
+    /**
+     * 检查队列是否为空
+     */
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+    
+    /**
+     * 清空队列
+     */
+    public void clear() {
+        int size = queue.size();
+        queue.clear();
+        log.info("Command queue cleared, removed {} commands", size);
+    }
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/watch/DocWatchManager.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/watch/DocWatchManager.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.watch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import jakarta.annotation.PreDestroy;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 文档监听管理器 - 管理多个文档的监听器
+ * MVP版本只支持单文档监听
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DocWatchManager {
+    
+    private final DocWatcher docWatcher;
+    
+    // 当前监听的文档列表（MVP版本只有一个）
+    private final Set<String> watchedDocs = ConcurrentHashMap.newKeySet();
+    
+    /**
+     * 开始监听文档
+     * MVP版本：只支持一个文档，新的文档会替换旧的
+     */
+    public void startWatching(String docToken) {
+        if (docToken == null || docToken.trim().isEmpty()) {
+            throw new IllegalArgumentException("Document token cannot be null or empty");
+        }
+        
+        // MVP版本：先停止之前的监听
+        stopAllWatching();
+        
+        // 开始新的监听
+        docWatcher.startWatching(docToken);
+        watchedDocs.add(docToken);
+        
+        log.info("DocWatchManager started watching document: {}", docToken);
+    }
+    
+    /**
+     * 停止监听指定文档
+     */
+    public void stopWatching(String docToken) {
+        if (docToken == null) {
+            return;
+        }
+        
+        if (watchedDocs.remove(docToken)) {
+            // 检查是否是当前监听的文档
+            if (docToken.equals(docWatcher.getCurrentDocToken())) {
+                docWatcher.stopWatching();
+                log.info("DocWatchManager stopped watching document: {}", docToken);
+            }
+        } else {
+            log.warn("Document {} is not being watched", docToken);
+        }
+    }
+    
+    /**
+     * 停止所有监听
+     */
+    public void stopAllWatching() {
+        if (!watchedDocs.isEmpty()) {
+            docWatcher.stopWatching();
+            watchedDocs.clear();
+            log.info("DocWatchManager stopped watching all documents");
+        }
+    }
+    
+    /**
+     * 检查是否正在监听指定文档
+     */
+    public boolean isWatching(String docToken) {
+        return watchedDocs.contains(docToken) && 
+               docToken.equals(docWatcher.getCurrentDocToken()) && 
+               docWatcher.isWatching();
+    }
+    
+    /**
+     * 获取当前监听的文档列表
+     */
+    public Set<String> getWatchedDocuments() {
+        return new HashSet<>(watchedDocs);
+    }
+    
+    /**
+     * 获取当前监听的文档数量
+     */
+    public int getWatchedDocumentCount() {
+        return watchedDocs.size();
+    }
+    
+    /**
+     * 获取当前活跃的监听器状态
+     */
+    public Map<String, Object> getWatcherStatus() {
+        Map<String, Object> status = new HashMap<>();
+        
+        String currentDoc = docWatcher.getCurrentDocToken();
+        status.put("currentDocument", currentDoc);
+        status.put("isWatching", docWatcher.isWatching());
+        status.put("idleCount", docWatcher.getIdleCount());
+        status.put("watchedDocuments", getWatchedDocuments());
+        
+        if (docWatcher.getLastSnapshot() != null) {
+            status.put("lastSnapshotTime", docWatcher.getLastSnapshot().getTimestamp());
+            status.put("lastCommentCount", docWatcher.getLastSnapshot().getCommentCount());
+        }
+        
+        return status;
+    }
+    
+    /**
+     * 应用关闭时清理资源
+     */
+    @PreDestroy
+    public void destroy() {
+        log.info("DocWatchManager shutting down...");
+        stopAllWatching();
+    }
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/watch/DocWatcher.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/watch/DocWatcher.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.watch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.mcp.samples.client.api.FeishuApi;
+import org.springframework.ai.mcp.samples.client.diff.CommentEventDetector;
+import org.springframework.ai.mcp.samples.client.event.CommentEventPublisher;
+import org.springframework.ai.mcp.samples.client.model.CommentEvent;
+import org.springframework.ai.mcp.samples.client.model.RawComment;
+import org.springframework.ai.mcp.samples.client.watch.snapshot.CommentSnapshot;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PreDestroy;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * 单文档监听器 - 定时轮询文档评论变更
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DocWatcher {
+    
+    private final FeishuApi feishuApi;
+    private final CommentEventDetector eventDetector;
+    private final CommentEventPublisher eventPublisher;
+    
+    @Value("${feicur.poll.interval:6000}")
+    private long pollInterval;
+    
+    @Value("${feicur.idle.limit:10}")
+    private int idleLimit;
+    
+    // 当前监听的文档token
+    private final AtomicReference<String> currentDocToken = new AtomicReference<>();
+    
+    // 上一次的快照
+    private final AtomicReference<CommentSnapshot> lastSnapshot = new AtomicReference<>();
+    
+    // 空闲计数器（连续无变更的次数）
+    private final AtomicInteger idleCount = new AtomicInteger(0);
+    
+    // 监听状态
+    private volatile boolean isWatching = false;
+    
+    /**
+     * 开始监听指定文档
+     */
+    public void startWatching(String docToken) {
+        if (docToken == null || docToken.trim().isEmpty()) {
+            throw new IllegalArgumentException("Document token cannot be null or empty");
+        }
+        
+        String oldToken = currentDocToken.getAndSet(docToken);
+        if (oldToken != null && !oldToken.equals(docToken)) {
+            log.info("Switching from doc {} to doc {}", oldToken, docToken);
+        }
+        
+        // 重置状态
+        lastSnapshot.set(null);
+        idleCount.set(0);
+        isWatching = true;
+        
+        log.info("Started watching document: {}", docToken);
+    }
+    
+    /**
+     * 停止监听
+     */
+    public void stopWatching() {
+        isWatching = false;
+        String docToken = currentDocToken.getAndSet(null);
+        lastSnapshot.set(null);
+        idleCount.set(0);
+        
+        if (docToken != null) {
+            log.info("Stopped watching document: {}", docToken);
+        }
+    }
+    
+    /**
+     * 定时轮询任务
+     */
+    @Scheduled(fixedDelayString = "${feicur.poll.interval:6000}")
+    public void pollComments() {
+        if (!isWatching) {
+            return;
+        }
+        
+        String docToken = currentDocToken.get();
+        if (docToken == null) {
+            return;
+        }
+        
+        try {
+            log.debug("Polling comments for document: {}", docToken);
+            
+            // 获取当前评论
+            List<RawComment> currentComments = feishuApi.listComments(docToken);
+            
+            // 创建新快照
+            CommentSnapshot newSnapshot = CommentSnapshot.fromComments(docToken, currentComments);
+            CommentSnapshot oldSnapshot = lastSnapshot.get();
+            
+            // 检测变更
+            List<CommentEvent> events = eventDetector.detectChanges(oldSnapshot, newSnapshot);
+            
+            if (events.isEmpty()) {
+                // 无变更，增加空闲计数
+                int currentIdleCount = idleCount.incrementAndGet();
+                log.debug("No changes detected, idle count: {}/{}", currentIdleCount, idleLimit);
+                
+                if (currentIdleCount >= idleLimit) {
+                    log.info("Reached idle limit ({}) for document: {}, stopping watch", 
+                            idleLimit, docToken);
+                    // 达到空闲限制，自动停止监听
+                    stopWatching();
+                    return; // 提前退出，避免更新快照
+                }
+            } else {
+                // 有变更，重置空闲计数
+                idleCount.set(0);
+                log.info("Detected {} comment events for document: {}", events.size(), docToken);
+                
+                // 发布事件
+                for (CommentEvent event : events) {
+                    eventPublisher.publishCommentChange(docToken, event);
+                }
+            }
+            
+            // 更新快照
+            lastSnapshot.set(newSnapshot);
+            
+        } catch (Exception e) {
+            log.error("Error occurred while polling comments for document: {}", docToken, e);
+            // 发生错误时增加空闲计数，避免频繁重试
+            idleCount.incrementAndGet();
+        }
+    }
+    
+    /**
+     * 获取当前监听状态
+     */
+    public boolean isWatching() {
+        return isWatching && currentDocToken.get() != null;
+    }
+    
+    /**
+     * 获取当前监听的文档token
+     */
+    public String getCurrentDocToken() {
+        return currentDocToken.get();
+    }
+    
+    /**
+     * 获取当前空闲计数
+     */
+    public int getIdleCount() {
+        return idleCount.get();
+    }
+    
+    /**
+     * 获取最后快照信息
+     */
+    public CommentSnapshot getLastSnapshot() {
+        return lastSnapshot.get();
+    }
+    
+    /**
+     * 应用关闭时清理资源
+     */
+    @PreDestroy
+    public void destroy() {
+        if (isWatching()) {
+            log.info("Application shutting down, stopping document watcher");
+            stopWatching();
+        }
+    }
+} 

--- a/src/main/java/org/springframework/ai/mcp/samples/client/watch/snapshot/CommentSnapshot.java
+++ b/src/main/java/org/springframework/ai/mcp/samples/client/watch/snapshot/CommentSnapshot.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.samples.client.watch.snapshot;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.springframework.ai.mcp.samples.client.model.RawComment;
+import java.time.Instant;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * 评论快照类 - 存储某个时刻的评论状态
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentSnapshot {
+    
+    /**
+     * 快照创建时间
+     */
+    private Instant timestamp;
+    
+    /**
+     * 文档Token
+     */
+    private String docToken;
+    
+    /**
+     * 评论ID到评论数据的映射
+     */
+    private Map<String, RawComment> commentMap;
+    
+    /**
+     * 评论ID到更新时间的映射（用于幂等检查）
+     */
+    private Map<String, Instant> updateTimeMap;
+    
+    /**
+     * 通过评论列表创建快照
+     */
+    public static CommentSnapshot fromComments(String docToken, List<RawComment> comments) {
+        CommentSnapshot snapshot = new CommentSnapshot();
+        snapshot.setTimestamp(Instant.now());
+        snapshot.setDocToken(docToken);
+        snapshot.setCommentMap(new HashMap<>());
+        snapshot.setUpdateTimeMap(new HashMap<>());
+        
+        for (RawComment comment : comments) {
+            if (comment.getCommentId() != null) {
+                snapshot.getCommentMap().put(comment.getCommentId(), comment);
+                if (comment.getUpdateTime() != null) {
+                    snapshot.getUpdateTimeMap().put(comment.getCommentId(), comment.getUpdateTime());
+                } else if (comment.getCreateTime() != null) {
+                    snapshot.getUpdateTimeMap().put(comment.getCommentId(), comment.getCreateTime());
+                }
+            }
+        }
+        
+        return snapshot;
+    }
+    
+    /**
+     * 获取评论数量
+     */
+    public int getCommentCount() {
+        return commentMap != null ? commentMap.size() : 0;
+    }
+    
+    /**
+     * 检查是否包含指定评论ID
+     */
+    public boolean containsComment(String commentId) {
+        return commentMap != null && commentMap.containsKey(commentId);
+    }
+    
+    /**
+     * 获取指定评论
+     */
+    public RawComment getComment(String commentId) {
+        return commentMap != null ? commentMap.get(commentId) : null;
+    }
+    
+    /**
+     * 获取指定评论的更新时间
+     */
+    public Instant getCommentUpdateTime(String commentId) {
+        return updateTimeMap != null ? updateTimeMap.get(commentId) : null;
+    }
+} 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,8 @@
 spring.application.name=mcp
-spring.main.web-application-type=none
+spring.main.web-application-type=servlet
+
+# Web服务器配置（v0.2版本启用）
+server.port=7777
 
 spring.ai.openai.api-key=${FEICUR_LLM_API_KEY}
 spring.ai.openai.base-url=${FEICUR_LLM_BASE_URL}
@@ -14,3 +17,28 @@ logging.level.io.modelcontextprotocol.spec=WARN
 ai.user.input=checkout user info from Feishu
 
 spring.ai.mcp.client.toolcallback.enabled=true
+
+# 文档监听配置
+feicur.poll.interval=1000
+feicur.idle.limit=30
+feicur.execute.interval=1
+
+# 重试配置
+spring.retry.enabled=true
+spring.retry.maxAttempts=3
+spring.retry.backoff.delay=1000
+spring.retry.backoff.multiplier=2
+
+# 断路器配置（Resilience4j）
+resilience4j.circuitbreaker.instances.feishu-api.failure-rate-threshold=50
+resilience4j.circuitbreaker.instances.feishu-api.wait-duration-in-open-state=30s
+resilience4j.circuitbreaker.instances.feishu-api.sliding-window-size=10
+resilience4j.circuitbreaker.instances.feishu-api.minimum-number-of-calls=5
+
+# 异步任务配置
+spring.task.execution.pool.core-size=5
+spring.task.execution.pool.max-size=10
+spring.task.execution.pool.queue-capacity=100
+
+# 启用调度和异步
+spring.task.scheduling.pool.size=5


### PR DESCRIPTION
## 概述

本PR实现了Issue #3中描述的文档监听与指令消费功能。

## 主要更新

### 核心功能
- ✅ 实现了对飞书文档评论的定时轮询监听
- ✅ 添加了评论变更检测和事件生成机制
- ✅ 实现了统一的指令队列和消费执行器
- ✅ 支持通过命令行参数启动文档监听
- ✅ 实现了评论事件到用户指令的映射转换
- ✅ 添加了自动停止监听机制（无变化时）

### 架构设计
- 采用Spring Boot的定时任务（@Scheduled）实现轮询
- 使用BlockingQueue实现线程安全的指令队列
- 通过事件发布订阅模式解耦组件
- 使用快照对比算法检测评论变更

### 新增组件
- `DocWatchManager`: 管理所有文档监听器
- `DocWatcher`: 单个文档的监听实现
- `CommentEventDetector`: 评论变更检测器
- `CommandQueue`: 指令队列管理
- `CommandExecutor`: 指令消费执行器
- `FeishuApi`: 封装的飞书API调用

## 使用方式

```bash
# 启动监听指定文档
java -jar feicur.jar --token=YOUR_DOC_TOKEN
```

## 测试
- 已在本地环境测试通过
- 可正确获取飞书文档评论
- 能检测新增评论、状态变更等事件
- 指令正确生成并在控制台输出

Closes #3